### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Proper kryptography requires security audits of the complete system.
 Even though the author is not aware of any bugs in this software, it
 comes with ABSOLUTELY NO WARRANTY. USE THIS SOFTWARE AT YOUR OWN RISK.
 
-.. image:: https://pypip.in/version/kryptomime/badge.svg
+.. image:: https://img.shields.io/pypi/v/kryptomime.svg
     :target: https://pypi.python.org/pypi/kryptomime/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20kryptomime))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `kryptomime`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.